### PR TITLE
chore: init-build-release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - uses: actions/checkout@v3
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          build_script_override: "script/build.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+dist

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "dev": "deno run --watch src/main.ts",
+    "compile": "deno run --allow-run=deno script/compile.ts",
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,16 @@
+{
+  "version": "2",
+  "remote": {
+    "https://deno.land/std@0.167.0/_util/asserts.ts": "d0844e9b62510f89ce1f9878b046f6a57bf88f208a10304aab50efcb48365272",
+    "https://deno.land/std@0.167.0/_util/os.ts": "8a33345f74990e627b9dfe2de9b040004b08ea5146c7c9e8fe9a29070d193934",
+    "https://deno.land/std@0.167.0/path/_constants.ts": "df1db3ffa6dd6d1252cc9617e5d72165cd2483df90e93833e13580687b6083c3",
+    "https://deno.land/std@0.167.0/path/_interface.ts": "ee3b431a336b80cf445441109d089b70d87d5e248f4f90ff906820889ecf8d09",
+    "https://deno.land/std@0.167.0/path/_util.ts": "d16be2a16e1204b65f9d0dfc54a9bc472cafe5f4a190b3c8471ec2016ccd1677",
+    "https://deno.land/std@0.167.0/path/common.ts": "bee563630abd2d97f99d83c96c2fa0cca7cee103e8cb4e7699ec4d5db7bd2633",
+    "https://deno.land/std@0.167.0/path/glob.ts": "81cc6c72be002cd546c7a22d1f263f82f63f37fe0035d9726aa96fc8f6e4afa1",
+    "https://deno.land/std@0.167.0/path/mod.ts": "cf7cec7ac11b7048bb66af8ae03513e66595c279c65cfa12bfc07d9599608b78",
+    "https://deno.land/std@0.167.0/path/posix.ts": "b859684bc4d80edfd4cad0a82371b50c716330bed51143d6dcdbe59e6278b30c",
+    "https://deno.land/std@0.167.0/path/separator.ts": "fe1816cb765a8068afb3e8f13ad272351c85cbc739af56dacfc7d93d710fe0f9",
+    "https://deno.land/std@0.167.0/path/win32.ts": "7cebd2bda6657371adc00061a1d23fdd87bcdf64b4843bb148b0b24c11b40f69"
+  }
+}

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+deno task compile "$@"

--- a/script/compile.ts
+++ b/script/compile.ts
@@ -1,0 +1,104 @@
+import { join } from "https://deno.land/std@0.167.0/path/mod.ts";
+
+const [version] = Deno.args;
+
+if (!version) {
+  console.error(
+    `[%cERROR%c] Incorrect version. %cExpected%c format "v*.*.*", %creceived%c "${version}"`,
+    "color: red",
+    "color: inherit",
+    "color: green",
+    "color: inherit",
+    "color: red",
+    "color: inherit",
+  );
+  Deno.exit(1);
+}
+
+enum Platform {
+  DARWIN = "darwin",
+  LINUX = "linux",
+  WINDOWS = "windows",
+}
+
+enum Arch {
+  AMD_64 = "amd64",
+  ARM_64 = "arm64",
+}
+
+interface Target {
+  platform: Platform;
+  arch: Arch;
+}
+
+const targets: Target[] = [
+  {
+    platform: Platform.DARWIN,
+    arch: Arch.AMD_64,
+  },
+  {
+    platform: Platform.DARWIN,
+    arch: Arch.ARM_64,
+  },
+  {
+    platform: Platform.LINUX,
+    arch: Arch.AMD_64,
+  },
+  {
+    platform: Platform.WINDOWS,
+    arch: Arch.AMD_64,
+  },
+];
+
+type DenoSupportedTargets =
+  | `${Platform.LINUX}-${Arch.AMD_64}`
+  | `${Platform.WINDOWS}-${Arch.AMD_64}`
+  | `${Platform.DARWIN}-${Arch.AMD_64}`
+  | `${Platform.DARWIN}-${Arch.ARM_64}`;
+
+const denoSupportedTargets: {
+  [key in DenoSupportedTargets as string]: string;
+} = {
+  "linux-amd64": "x86_64-unknown-linux-gnu",
+  "windows-amd64": "x86_64-pc-windows-msvc",
+  "darwin-amd64": "x86_64-apple-darwin",
+  "darwin-arm64": "aarch64-apple-darwin",
+};
+
+const outDir = "dist";
+
+for (const { platform, arch } of targets) {
+  const denoSupportedTarget = denoSupportedTargets[`${platform}-${arch}`];
+
+  if (!denoSupportedTarget) {
+    console.warn(
+      `[%cWARN%c] Deno does not support compiling to "${platform}-${arch}" systems. Skipping.`,
+      "color: orange",
+      "color: inherit",
+    );
+    continue;
+  }
+
+  const filename = `gh-contribution-mate_${platform}-${arch}`;
+
+  const { success, code } = await Deno.run({
+    cmd: [
+      "deno",
+      "compile",
+      "-o",
+      join(outDir, filename),
+      "--target",
+      denoSupportedTarget,
+      "src/main.ts",
+    ],
+  }).status();
+
+  if (!success) {
+    console.error(
+      `[%cERROR%c] Compilation of "${filename}" failed, status code: ${code}`,
+      "color: red",
+      "color: inherit",
+    );
+    Deno.exit(code);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,1 @@
+console.log("Hello World, my name is Contribution Mate!");


### PR DESCRIPTION
Minimal Deno setup with compiling and release workflow.

You cannot test the release workflow until merged into the main.
I think we can start with `v0.1.0-rc.1` to test if the workflow works fine, and then we do a release to see if the extension is installable and works as expected.

Unfortunately, it's unclear in the [Creating GitHub CLI extensions](https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions) documentation whenever it's going to work with the non-Go compilation the same way. We will have to try and see.