### PR TITLE
refactor: united config usage in config comman

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -373,7 +373,9 @@
     "packages": {
       "@babel/code-frame@7.18.6": {
         "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-        "dependencies": { "@babel/highlight": "@babel/highlight@7.18.6" }
+        "dependencies": {
+          "@babel/highlight": "@babel/highlight@7.18.6"
+        }
       },
       "@babel/helper-validator-identifier@7.19.1": {
         "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
@@ -455,7 +457,9 @@
       },
       "@commitlint/types@17.4.0": {
         "integrity": "sha512-2NjAnq5IcxY9kXtUeO2Ac0aPpvkuOmwbH/BxIm36XXK5LtWFObWJWjXOA+kcaABMrthjWu6la+FUpyYFMHRvbA==",
-        "dependencies": { "chalk": "chalk@4.1.2" }
+        "dependencies": {
+          "chalk": "chalk@4.1.2"
+        }
       },
       "@types/minimist@1.2.2": {
         "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
@@ -474,11 +478,15 @@
       },
       "ansi-styles@3.2.1": {
         "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-        "dependencies": { "color-convert": "color-convert@1.9.3" }
+        "dependencies": {
+          "color-convert": "color-convert@1.9.3"
+        }
       },
       "ansi-styles@4.3.0": {
         "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-        "dependencies": { "color-convert": "color-convert@2.0.1" }
+        "dependencies": {
+          "color-convert": "color-convert@2.0.1"
+        }
       },
       "array-ify@1.0.0": {
         "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
@@ -517,11 +525,15 @@
       },
       "color-convert@1.9.3": {
         "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-        "dependencies": { "color-name": "color-name@1.1.3" }
+        "dependencies": {
+          "color-name": "color-name@1.1.3"
+        }
       },
       "color-convert@2.0.1": {
         "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-        "dependencies": { "color-name": "color-name@1.1.4" }
+        "dependencies": {
+          "color-name": "color-name@1.1.4"
+        }
       },
       "color-name@1.1.3": {
         "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
@@ -540,7 +552,10 @@
       },
       "conventional-changelog-angular@5.0.13": {
         "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
-        "dependencies": { "compare-func": "compare-func@2.0.0", "q": "q@1.5.1" }
+        "dependencies": {
+          "compare-func": "compare-func@2.0.0",
+          "q": "q@1.5.1"
+        }
       },
       "conventional-changelog-conventionalcommits@5.0.0": {
         "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
@@ -582,11 +597,15 @@
       },
       "dot-prop@5.3.0": {
         "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-        "dependencies": { "is-obj": "is-obj@2.0.0" }
+        "dependencies": {
+          "is-obj": "is-obj@2.0.0"
+        }
       },
       "error-ex@1.3.2": {
         "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-        "dependencies": { "is-arrayish": "is-arrayish@0.2.1" }
+        "dependencies": {
+          "is-arrayish": "is-arrayish@0.2.1"
+        }
       },
       "escape-string-regexp@1.0.5": {
         "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
@@ -635,7 +654,9 @@
       },
       "has@1.0.3": {
         "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-        "dependencies": { "function-bind": "function-bind@1.1.1" }
+        "dependencies": {
+          "function-bind": "function-bind@1.1.1"
+        }
       },
       "hosted-git-info@2.8.9": {
         "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
@@ -643,7 +664,9 @@
       },
       "hosted-git-info@4.1.0": {
         "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-        "dependencies": { "lru-cache": "lru-cache@6.0.0" }
+        "dependencies": {
+          "lru-cache": "lru-cache@6.0.0"
+        }
       },
       "human-signals@2.1.0": {
         "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
@@ -663,7 +686,9 @@
       },
       "is-core-module@2.11.0": {
         "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-        "dependencies": { "has": "has@1.0.3" }
+        "dependencies": {
+          "has": "has@1.0.3"
+        }
       },
       "is-obj@2.0.0": {
         "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
@@ -679,7 +704,9 @@
       },
       "is-text-path@1.0.1": {
         "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
-        "dependencies": { "text-extensions": "text-extensions@1.9.0" }
+        "dependencies": {
+          "text-extensions": "text-extensions@1.9.0"
+        }
       },
       "isexe@2.0.0": {
         "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
@@ -707,7 +734,9 @@
       },
       "locate-path@5.0.0": {
         "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-        "dependencies": { "p-locate": "p-locate@4.1.0" }
+        "dependencies": {
+          "p-locate": "p-locate@4.1.0"
+        }
       },
       "lodash.camelcase@4.3.0": {
         "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
@@ -735,7 +764,9 @@
       },
       "lru-cache@6.0.0": {
         "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-        "dependencies": { "yallist": "yallist@4.0.0" }
+        "dependencies": {
+          "yallist": "yallist@4.0.0"
+        }
       },
       "map-obj@1.0.1": {
         "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
@@ -801,19 +832,27 @@
       },
       "npm-run-path@4.0.1": {
         "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-        "dependencies": { "path-key": "path-key@3.1.1" }
+        "dependencies": {
+          "path-key": "path-key@3.1.1"
+        }
       },
       "onetime@5.1.2": {
         "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-        "dependencies": { "mimic-fn": "mimic-fn@2.1.0" }
+        "dependencies": {
+          "mimic-fn": "mimic-fn@2.1.0"
+        }
       },
       "p-limit@2.3.0": {
         "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-        "dependencies": { "p-try": "p-try@2.2.0" }
+        "dependencies": {
+          "p-try": "p-try@2.2.0"
+        }
       },
       "p-locate@4.1.0": {
         "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-        "dependencies": { "p-limit": "p-limit@2.3.0" }
+        "dependencies": {
+          "p-limit": "p-limit@2.3.0"
+        }
       },
       "p-try@2.2.0": {
         "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
@@ -898,11 +937,15 @@
       },
       "semver@7.3.8": {
         "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-        "dependencies": { "lru-cache": "lru-cache@6.0.0" }
+        "dependencies": {
+          "lru-cache": "lru-cache@6.0.0"
+        }
       },
       "shebang-command@2.0.0": {
         "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-        "dependencies": { "shebang-regex": "shebang-regex@3.0.0" }
+        "dependencies": {
+          "shebang-regex": "shebang-regex@3.0.0"
+        }
       },
       "shebang-regex@3.0.0": {
         "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
@@ -936,11 +979,15 @@
       },
       "split2@3.2.2": {
         "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-        "dependencies": { "readable-stream": "readable-stream@3.6.0" }
+        "dependencies": {
+          "readable-stream": "readable-stream@3.6.0"
+        }
       },
       "string_decoder@1.3.0": {
         "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-        "dependencies": { "safe-buffer": "safe-buffer@5.2.1" }
+        "dependencies": {
+          "safe-buffer": "safe-buffer@5.2.1"
+        }
       },
       "strip-final-newline@2.0.0": {
         "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
@@ -948,15 +995,21 @@
       },
       "strip-indent@3.0.0": {
         "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-        "dependencies": { "min-indent": "min-indent@1.0.1" }
+        "dependencies": {
+          "min-indent": "min-indent@1.0.1"
+        }
       },
       "supports-color@5.5.0": {
         "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-        "dependencies": { "has-flag": "has-flag@3.0.0" }
+        "dependencies": {
+          "has-flag": "has-flag@3.0.0"
+        }
       },
       "supports-color@7.2.0": {
         "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-        "dependencies": { "has-flag": "has-flag@4.0.0" }
+        "dependencies": {
+          "has-flag": "has-flag@4.0.0"
+        }
       },
       "supports-preserve-symlinks-flag@1.0.0": {
         "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
@@ -968,7 +1021,9 @@
       },
       "through2@4.0.2": {
         "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-        "dependencies": { "readable-stream": "readable-stream@3.6.0" }
+        "dependencies": {
+          "readable-stream": "readable-stream@3.6.0"
+        }
       },
       "through@2.3.8": {
         "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
@@ -1003,7 +1058,9 @@
       },
       "which@2.0.2": {
         "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-        "dependencies": { "isexe": "isexe@2.0.0" }
+        "dependencies": {
+          "isexe": "isexe@2.0.0"
+        }
       },
       "yallist@4.0.0": {
         "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",

--- a/src/models/git/git.ts
+++ b/src/models/git/git.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { isEmpty } from 'rambda';
 
 export type GitAuthor = z.infer<typeof GitAuthor>;
 export const GitAuthor = z.object({
@@ -13,7 +14,9 @@ async function getGitConfigParam(key: string): Promise<string | undefined> {
   });
   const { success } = await proc.status();
   if (!success) return;
-  return new TextDecoder().decode(await proc.output()).trim();
+  const result = new TextDecoder().decode(await proc.output()).trim();
+  if (isEmpty(result)) return;
+  return result;
 }
 
 export async function getGitAuthor(): Promise<GitAuthor> {


### PR DESCRIPTION
The config command receives the configuration object instead of collecting its entries separately. Also, I got rid of unnecessary types and replaced others with inferred from zod schema types where applicable.