### PR TITLE
refactor: memoize getRepository responses

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,6 +6,7 @@
     "cliffy": "https://deno.land/x/cliffy@v0.25.6/mod.ts",
     "zod": "https://deno.land/x/zod@v3.20.1/mod.ts",
     "rambda": "https://mckgnjtrq3abdh6fhic5ddwopjdoxtpu2vvkyphhzwui4egizoma.arweave.net/YJRmpnGGwBGfxToF0Y7OekbrzfTVaqw8582ojhDIy5g/mod.ts",
+    "memoizy": "https://deno.land/x/memoizy@1.0.0/mod.ts",
     "version": "./version.ts",
     "commands/config": "./src/commands/config/mod.ts",
     "models/repository": "./src/models/repository/mod.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -139,6 +139,7 @@
     "https://deno.land/x/dir@1.5.1/home_dir/mod.ts": "53777e4fb2586ae02ce94adf2c99f2edb2dcf6e72d07ac289b71593cfacbdbbf",
     "https://deno.land/x/dir@1.5.1/mod.ts": "95e1519b7b629c995025652342b36fbf64a6a9a0bd7822b0c4573a22f42f0529",
     "https://deno.land/x/dir@1.5.1/tmp_dir/mod.ts": "b2422e886d444f6cfc75340e438fa4dd458c951f81452f7634ae444d2e7a3e3f",
+    "https://deno.land/x/memoizy@1.0.0/mod.ts": "8b421c57a2c9bcf60f0d845aa46d19b09de838953c9d440d9abbc8e3cabb791b",
     "https://deno.land/x/zod@v3.20.1/ZodError.ts": "b4ff327bd2870a7c0930b30cb1d6eb741d36a5a7d0755fc3aa7146c108bc8a0e",
     "https://deno.land/x/zod@v3.20.1/errors.ts": "5285922d2be9700cc0c70c95e4858952b07ae193aa0224be3cbd5cd5567eabef",
     "https://deno.land/x/zod@v3.20.1/external.ts": "a6cfbd61e9e097d5f42f8a7ed6f92f93f51ff927d29c9fbaec04f03cbce130fe",

--- a/src/models/repository/repository.ts
+++ b/src/models/repository/repository.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { isEmpty, tryCatch } from 'rambda';
+import { memoizy } from 'memoizy';
 
 export class RepositoryError extends Error {
   constructor(message: string = 'Repository error') {
@@ -29,12 +30,10 @@ export function isRepository(obj: unknown): obj is Repository {
   }
 }
 
-let cachedRepository: Repository | null = null;
-
-function setCachedRepository(
+function constructRepositoryObj(
   { name, isFork, isPrivate, url, isInOrganization, owner }: Repository,
 ): Repository {
-  cachedRepository = {
+  return {
     name,
     isFork,
     isPrivate,
@@ -42,7 +41,6 @@ function setCachedRepository(
     isInOrganization,
     owner: { login: owner.login },
   };
-  return cachedRepository;
 }
 
 // ? Probably not the right place for it. New user model?
@@ -57,7 +55,7 @@ async function getUsername() {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
 
-  await proc.stdin.write(encoder.encode(`gh api user | jq -r '.login'`));
+  await proc.stdin.write(encoder.encode(`gh api user`));
   await proc.stdin.close();
   const stderr = decoder.decode(await proc.stderrOutput()).trim();
   proc.close();
@@ -66,80 +64,76 @@ async function getUsername() {
     throw new Error(stderr);
   }
 
-  const stdout = decoder.decode(await proc.output()).trim();
-  return stdout;
+  const repository = JSON.parse(decoder.decode(await proc.output()).trim());
+  return repository.login;
 }
 
-export async function getRepository(
-  { name }: Pick<Repository, 'name'>,
-): Promise<Repository> {
-  if (cachedRepository && cachedRepository.name === name) {
-    return cachedRepository;
-  }
+export const getRepository = memoizy(
+  async ({ name }: Pick<Repository, 'name'>): Promise<Repository> => {
+    /**
+     * Be aware that json options are not type-safe at the moment.
+     * In case a change is needed make sure this is aligned with the `Repository` type.
+     */
+    const proc = Deno.run({
+      cmd: [
+        'gh',
+        'repo',
+        'view',
+        name,
+        '--json',
+        'isFork,isPrivate,name,url,isInOrganization,owner',
+      ],
+      stdout: 'piped',
+      stderr: 'piped',
+    });
+    const decoder = new TextDecoder();
+    const stdout = decoder.decode(await proc.output()).trim();
+    const stderr = decoder.decode(await proc.stderrOutput()).trim();
 
-  /**
-   * Be aware that json options are not type-safe at the moment.
-   * In case a change is needed make sure this is aligned with the `Repository` type.
-   */
-  const proc = Deno.run({
-    cmd: [
-      'gh',
-      'repo',
-      'view',
-      name,
-      '--json',
-      'isFork,isPrivate,name,url,isInOrganization,owner',
-    ],
-    stdout: 'piped',
-    stderr: 'piped',
-  });
-  const decoder = new TextDecoder();
-  const stdout = decoder.decode(await proc.output()).trim();
-  const stderr = decoder.decode(await proc.stderrOutput()).trim();
+    proc.close();
 
-  proc.close();
+    /**
+     * In case there's an unexpected error from the `gh` command, we want to stop the execution completely.
+     */
+    if (!isEmpty(stderr) && !stderr.includes(name)) {
+      console.error('ERROR', stderr);
+      Deno.exit(1);
+    }
 
-  /**
-   * In case there's an unexpected error from the `gh` command, we want to stop the execution completely.
-   */
-  if (!isEmpty(stderr) && !stderr.includes(name)) {
-    console.error('ERROR', stderr);
-    Deno.exit(1);
-  }
+    /**
+     * In case the repository doesn't exist, we want to throw an error.
+     */
+    if (!isEmpty(stderr) && stderr.includes(name)) {
+      throw new RepositoryError('Repository not found');
+    }
 
-  /**
-   * In case the repository doesn't exist, we want to throw an error.
-   */
-  if (!isEmpty(stderr) && stderr.includes(name)) {
-    throw new RepositoryError('Repository not found');
-  }
+    /**
+     * In case the repository exists, we want to parse the JSON response and cache it.
+     * If the parsing fails, we want to stop the execution completely.
+     */
+    const obj: unknown = tryCatch(JSON.parse, () => {
+      console.error('ERROR', 'Failed to parse JSON response');
+      Deno.exit(1);
+    })(stdout);
 
-  /**
-   * In case the repository exists, we want to parse the JSON response and cache it.
-   * If the parsing fails, we want to stop the execution completely.
-   */
-  const obj: unknown = tryCatch(JSON.parse, () => {
-    console.error('ERROR', 'Failed to parse JSON response');
-    Deno.exit(1);
-  })(stdout);
+    const username = await getUsername();
 
-  const username = await getUsername();
+    if (
+      !isRepository(obj) || obj.isFork || obj.isInOrganization ||
+      obj.owner.login !== username
+    ) {
+      console.error(
+        'ERROR',
+        'Invalid repository - this repository cannot be used',
+        '\n',
+        'Make sure the repository is not a fork, not in an organization and belongs to the current user',
+      );
+      throw new RepositoryError('Invalid repository');
+    }
 
-  if (
-    !isRepository(obj) || obj.isFork || obj.isInOrganization ||
-    obj.owner.login !== username
-  ) {
-    console.error(
-      'ERROR',
-      'Invalid repository - this repository cannot be used',
-      '\n',
-      'Make sure the repository is not a fork, not in an organization and belongs to the current user',
-    );
-    throw new RepositoryError('Invalid repository');
-  }
-
-  return setCachedRepository(obj);
-}
+    return constructRepositoryObj(obj);
+  },
+);
 
 export async function createRepository(
   { name }: Pick<Repository, 'name'>,

--- a/src/models/repository/repository.ts
+++ b/src/models/repository/repository.ts
@@ -64,8 +64,8 @@ async function getUsername() {
     throw new Error(stderr);
   }
 
-  const repository = JSON.parse(decoder.decode(await proc.output()).trim());
-  return repository.login;
+  const { login: username } = JSON.parse(decoder.decode(await proc.output()).trim());
+  return username;
 }
 
 export const getRepository = memoizy(

--- a/src/models/repository/repository.ts
+++ b/src/models/repository/repository.ts
@@ -64,7 +64,9 @@ async function getUsername() {
     throw new Error(stderr);
   }
 
-  const { login: username } = JSON.parse(decoder.decode(await proc.output()).trim());
+  const { login: username } = JSON.parse(
+    decoder.decode(await proc.output()).trim(),
+  );
   return username;
 }
 


### PR DESCRIPTION
close #45 

I've also dropped `jq` command usage and replaced it with `JSON.parse` for now. Not everyone have `jq` installed (as it happened I didn't have one on my new machine), so it's probably for the best. We might need to come back and improve this part later, but as long as GitHub responds with JSON there should be no problem.